### PR TITLE
Expose buffer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ usage: ipfix-forwarder [server-flags] [vendor(s)] [syslog-export-info] [logging-
         IP the server will be listening to. (default "0.0.0.0")
   -server-port int
         Port we will be listening on. (default 2055)
+  -server-rcvbuf int
+        Size of OS receive buffer associated with the connection. (default 2097152)
+  -server-sndbuf int
+        Size of OS transmit buffer associated with the connection. (default 2097152)
   -stderrthreshold value
         logs at or above this threshold go to stderr
   -v value

--- a/options.go
+++ b/options.go
@@ -31,6 +31,10 @@ func parseOptions() {
 		"IP the server will be listening to.")
 	serverPort := flag.Int("server-port", 2055,
 		"Port we will be listening on.")
+	serverRcvBuf := flag.Int("server-rcvbuf", 2097152,
+		"Size of OS receive buffer associated with the connection.")
+	serverSndBuf := flag.Int("server-sndbuf", 2097152,
+		"Size of OS transmit buffer associated with the connection.")
 
 	numCPU := flag.Int("num-cpu", runtime.NumCPU(),
 		"Number of CPUs to leverage.")
@@ -105,6 +109,8 @@ func parseOptions() {
 	globalServerOptions = ServerOptions{
 		address:          *serverAddr,
 		port:             *serverPort,
+		rcvbuf:           *serverRcvBuf,
+		sndbuf:           *serverSndBuf,
 		numCPU:           *numCPU,
 		exportSyslogInfo: exportSyslogInfo,
 		vendors:          vendors,

--- a/server.go
+++ b/server.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"github.com/golang/glog"
 	"net"
 	"strconv"
-	"github.com/golang/glog"
 	"sync"
 )
 
@@ -65,6 +65,16 @@ func (server *Server) Listen() {
 			panic(err)
 		}
 		defer conn.Close()
+
+		err = conn.SetReadBuffer(globalServerOptions.rcvbuf)
+		if err != nil {
+			glog.Errorln(err)
+		}
+		err = conn.SetWriteBuffer(globalServerOptions.sndbuf)
+		if err != nil {
+			glog.Errorln(err)
+		}
+
 		server.setConn(conn)
 
 		for {

--- a/type.go
+++ b/type.go
@@ -6,6 +6,8 @@ import "github.com/calmh/ipfix"
 type ServerOptions struct {
 	address          string
 	port             int
+	rcvbuf           int
+	sndbuf           int
 	numCPU           int
 	vendors          []string
 	exportSyslogInfo ExportSyslogInfo


### PR DESCRIPTION
This one exposes options for the size of OS receive/send UDP buffer. It can be important because in Go there are some default values and it will not look at kernel settings but will use their default instead.